### PR TITLE
Exclude metadata/prerelease tags.

### DIFF
--- a/git/tag.go
+++ b/git/tag.go
@@ -37,7 +37,7 @@ func (g Git) PushTag(t tag.Tag) (err error) {
 func runGitDescribe() (string, error) {
 	// The following glob(7) pattern is not perfect. It will match things like v1.4badstring.8
 	// But it narrows down the results by a good bit. It will exclude prerelease tags such as `v1.4.8-rc-1`
-	cmd := exec.Command("git", "describe", "--abbrev=0", "--tags", "--match=v[0-9]*\\.[0-9]*\\.[0-9]*", "--exclude=v[0-9] *\\.[0 - 9]*\\.[0 - 9]*-*")
+	cmd := exec.Command("git", "describe", "--abbrev=0", "--tags", "--match=v[0-9]*\\.[0-9]*\\.[0-9]*", "--exclude=v[0-9]*\\.[0-9]*\\.[0-9]*-*")
 	// TODO: if we find a tag, but it's invalid (human created), we should retry and find the one previous.
 	// Probably with a `git describe <bad tag that was found>`
 	return runCommand(cmd)

--- a/git/tag.go
+++ b/git/tag.go
@@ -36,8 +36,8 @@ func (g Git) PushTag(t tag.Tag) (err error) {
 
 func runGitDescribe() (string, error) {
 	// The following glob(7) pattern is not perfect. It will match things like v1.4badstring.8
-	// But it narrows down the results by a good bit
-	cmd := exec.Command("git", "describe", "--abbrev=0", "--tags", "--match=v[0-9]*\\.[0-9]*\\.[0-9]*")
+	// But it narrows down the results by a good bit. It will exclude prerelease tags such as `v1.4.8-rc-1`
+	cmd := exec.Command("git", "describe", "--abbrev=0", "--tags", "--match=v[0-9]*\\.[0-9]*\\.[0-9]*", "--exclude=v[0-9] *\\.[0 - 9]*\\.[0 - 9]*-*")
 	// TODO: if we find a tag, but it's invalid (human created), we should retry and find the one previous.
 	// Probably with a `git describe <bad tag that was found>`
 	return runCommand(cmd)


### PR DESCRIPTION
# Description

This PR extends the glob used for finding the last semver tag, ignoring any pre-release or metadata tags as stated in Issue #10 .

## Important Information

To test, tag locally a metadata tag

e.g.) `git tag v2.0.4-prod` and run the command. `git describe --tags --abbrev=0 --match="v[0-9]*\\.[0-9]*\\.[0-9]*" --exclude="v[0-9]*\\.[0-9]*\\.[0-9]*-*"`

## Versioning
This PR will bump the version by one `fix` level.

## I've done the steps below, and they work properly:
- [ ] Update/Add Tests
- [X] Manual sanity checking


<details>
<summary>Reviewers...</summary>

```markdown
### I confirm that:
- [ ] PR addresses intended issue, with smallest scope possible
- [ ] Code is of acceptable quality
- [ ] Code is properly tested (quantity and quality)
- [ ] Bumping **minor** level is appropriate
```
</details>
